### PR TITLE
Translate userprog comments to Korean

### DIFF
--- a/pintos-kaist/userprog/exception.c
+++ b/pintos-kaist/userprog/exception.c
@@ -6,27 +6,23 @@
 #include "threads/thread.h"
 #include "intrinsic.h"
 
-/* Number of page faults processed. */
+/* 처리한 페이지 폴트의 수. */
 static long long page_fault_cnt;
 
 static void kill (struct intr_frame *);
 static void page_fault (struct intr_frame *);
 
-/* Registers handlers for interrupts that can be caused by user
-   programs.
+/* 사용자 프로그램에서 발생 가능한 인터럽트의 핸들러를 등록한다.
 
-   In a real Unix-like OS, most of these interrupts would be
-   passed along to the user process in the form of signals, as
-   described in [SV-386] 3-24 and 3-25, but we don't implement
-   signals.  Instead, we'll make them simply kill the user
-   process.
+   실제 유닉스 계열 OS에서는 [SV-386] 3-24, 3-25에 설명된 것처럼
+   대부분의 인터럽트를 시그널 형태로 사용자 프로세스에게 전달하지만
+   Pintos에서는 시그널을 지원하지 않으므로 단순히 프로세스를 종료한다.
 
-   Page faults are an exception.  Here they are treated the same
-   way as other exceptions, but this will need to change to
-   implement virtual memory.
+   페이지 폴트는 예외 사항으로, 현재는 다른 예외처럼 처리하지만
+   가상 메모리를 구현하려면 별도의 처리가 필요하다.
 
-   Refer to [IA32-v3a] section 5.15 "Exception and Interrupt
-   Reference" for a description of each of these exceptions. */
+   각 예외에 대한 자세한 내용은 [IA32-v3a] 5.15 "Exception and Interrupt
+   Reference"를 참고하라. */
 void
 exception_init (void) {
 	/* These exceptions can be raised explicitly by a user program,
@@ -60,62 +56,53 @@ exception_init (void) {
 	intr_register_int (14, 0, INTR_OFF, page_fault, "#PF Page-Fault Exception");
 }
 
-/* Prints exception statistics. */
+/* 예외 통계를 출력한다. */
 void
 exception_print_stats (void) {
 	printf ("Exception: %lld page faults\n", page_fault_cnt);
 }
 
-/* Handler for an exception (probably) caused by a user process. */
+/* 사용자 프로세스가 일으킨 것으로 보이는 예외를 처리한다. */
 static void
 kill (struct intr_frame *f) {
-	/* This interrupt is one (probably) caused by a user process.
-	   For example, the process might have tried to access unmapped
-	   virtual memory (a page fault).  For now, we simply kill the
-	   user process.  Later, we'll want to handle page faults in
-	   the kernel.  Real Unix-like operating systems pass most
-	   exceptions back to the process via signals, but we don't
-	   implement them. */
+        /* 이 인터럽트는 사용자 프로세스가 발생시킨 것으로 보인다.
+           예를 들어 매핑되지 않은 가상 주소에 접근해 페이지 폴트가
+           발생했을 수 있다. 지금은 프로세스를 종료하지만, 나중에는
+           커널에서 페이지 폴트를 처리해야 한다. 실제 유닉스 계열 OS는
+           대부분의 예외를 시그널로 돌려주지만 Pintos는 시그널을 지원하지 않는다. */
 
-	/* The interrupt frame's code segment value tells us where the
-	   exception originated. */
+        /* 인터럽트 프레임의 코드 세그먼트 값으로 예외가 어디서 발생했는지 알 수 있다. */
 	switch (f->cs) {
 		case SEL_UCSEG:
-			/* User's code segment, so it's a user exception, as we
-			   expected.  Kill the user process.  */
+                        /* 사용자 코드 세그먼트라면 예상대로 사용자 예외이므로 프로세스를 종료한다. */
 			printf ("%s: dying due to interrupt %#04llx (%s).\n",
 					thread_name (), f->vec_no, intr_name (f->vec_no));
 			intr_dump_frame (f);
 			thread_exit ();
 
 		case SEL_KCSEG:
-			/* Kernel's code segment, which indicates a kernel bug.
-			   Kernel code shouldn't throw exceptions.  (Page faults
-			   may cause kernel exceptions--but they shouldn't arrive
-			   here.)  Panic the kernel to make the point.  */
+                        /* 커널 코드 세그먼트라면 커널 버그를 의미한다.
+                           커널에서 예외가 발생하면 안 되며(페이지 폴트가 생겨도 여기까지 오면 안 된다).
+                           따라서 커널을 패닉시킨다. */
 			intr_dump_frame (f);
 			PANIC ("Kernel bug - unexpected interrupt in kernel");
 
 		default:
-			/* Some other code segment?  Shouldn't happen.  Panic the
-			   kernel. */
+                        /* 그 밖의 세그먼트에서 발생했다면 있을 수 없는 상황이므로 커널을 패닉시킨다. */
 			printf ("Interrupt %#04llx (%s) in unknown segment %04x\n",
 					f->vec_no, intr_name (f->vec_no), f->cs);
 			thread_exit ();
 	}
 }
 
-/* Page fault handler.  This is a skeleton that must be filled in
-   to implement virtual memory.  Some solutions to project 2 may
-   also require modifying this code.
+/* 페이지 폴트 핸들러로, 가상 메모리를 구현하려면 이 뼈대를 채워야 한다.
+   프로젝트 2의 해법에 따라서는 이 코드를 수정해야 할 수도 있다.
 
-   At entry, the address that faulted is in CR2 (Control Register
-   2) and information about the fault, formatted as described in
-   the PF_* macros in exception.h, is in F's error_code member.  The
-   example code here shows how to parse that information.  You
-   can find more information about both of these in the
-   description of "Interrupt 14--Page Fault Exception (#PF)" in
-   [IA32-v3a] section 5.15 "Exception and Interrupt Reference". */
+   진입하면 CR2 레지스터에 장애가 발생한 주소가 있고,
+   fault 정보는 exception.h의 PF_* 매크로 형식으로 intr_frame의 error_code에 담겨 있다.
+   아래 예제는 그 정보를 해석하는 방법을 보여 준다.
+   자세한 내용은 [IA32-v3a] 5.15 "Exception and Interrupt Reference"의
+   "Interrupt 14--Page Fault Exception(#PF)" 항목을 참고하라. */
 static void
 page_fault (struct intr_frame *f) {
 	bool not_present;  /* True: not-present page, false: writing r/o page. */
@@ -123,36 +110,34 @@ page_fault (struct intr_frame *f) {
 	bool user;         /* True: access by user, false: access by kernel. */
 	void *fault_addr;  /* Fault address. */
 
-	/* Obtain faulting address, the virtual address that was
-	   accessed to cause the fault.  It may point to code or to
-	   data.  It is not necessarily the address of the instruction
-	   that caused the fault (that's f->rip). */
+        /* 오류를 일으킨 가상 주소를 얻는다.
+           코드나 데이터 어느 쪽일 수도 있으며,
+           예외를 발생시킨 명령어의 주소(f->rip)와 반드시 같지는 않다. */
 
 	fault_addr = (void *) rcr2();
 
-	/* Turn interrupts back on (they were only off so that we could
-	   be assured of reading CR2 before it changed). */
+        /* CR2 값을 읽기 전까지 잠시 꺼 두었던 인터럽트를 다시 활성화한다. */
 	intr_enable ();
 
 
-	/* Determine cause. */
+        /* 원인을 파악한다. */
 	not_present = (f->error_code & PF_P) == 0;
 	write = (f->error_code & PF_W) != 0;
 	user = (f->error_code & PF_U) != 0;
 
 #ifdef VM
-	/* For project 3 and later. */
+        /* 프로젝트 3 이후 버전을 위한 처리. */
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
 		return;
 #endif
 
-	/* Count page faults. */
-	page_fault_cnt++;
+        /* 페이지 폴트 횟수를 기록한다. */
+        page_fault_cnt++;
 
-	/* Exit in userprog */
+        /* userprog에서 종료 */
 	sys_exit(-1);
 
-	/* If the fault is true fault, show info and exit. */
+        /* 진짜 오류라면 정보를 출력하고 종료한다. */
 	printf ("Page fault at %p: %s error %s page in %s context.\n",
 			fault_addr,
 			not_present ? "not present" : "rights violation",

--- a/pintos-kaist/userprog/gdt.c
+++ b/pintos-kaist/userprog/gdt.c
@@ -6,20 +6,15 @@
 #include "threads/vaddr.h"
 #include "intrinsic.h"
 
-/* The Global Descriptor Table (GDT).
+/* 전역 디스크립터 테이블(GDT).
  *
- * The GDT, an x86-64 specific structure, defines segments that can
- * potentially be used by all processes in a system, subject to
- * their permissions.  There is also a per-process Local
- * Descriptor Table (LDT) but that is not used by modern
- * operating systems.
+ * GDT는 x86-64에서 사용되는 구조로, 시스템의 모든 프로세스가
+ * 권한에 따라 사용할 수 있는 세그먼트를 정의한다. 각 프로세스마다
+ * Local Descriptor Table(LDT)이 존재하지만 현대 OS에서는 쓰이지 않는다.
  *
- * Each entry in the GDT, which is known by its byte offset in
- * the table, identifies a segment.  For our purposes only three
- * types of segments are of interest: code, data, and TSS or
- * Task-State Segment descriptors.  The former two types are
- * exactly what they sound like.  The TSS is used primarily for
- * stack switching on interrupts. */
+ * GDT의 각 항목은 테이블에서의 바이트 오프셋으로 구분되며,
+ * 우리가 관심 있게 볼 세그먼트는 코드, 데이터, 그리고 TSS(Task-State Segment) 세 가지다.
+ * 앞의 두 종류는 이름 그대로이고, TSS는 인터럽트 시 스택을 전환하는 데 주로 사용된다. */
 
 struct segment_desc {
 	unsigned lim_15_0 : 16;
@@ -77,11 +72,11 @@ struct desc_ptr gdt_ds = {
 	.address = (uint64_t) gdt
 };
 
-/* Sets up a proper GDT.  The bootstrap loader's GDT didn't
-   include user-mode selectors or a TSS, but we need both now. */
+/* 부트스트랩 단계에서 사용된 GDT에는 사용자 모드 세그먼트와 TSS가 없으므로
+   이를 갖춘 올바른 GDT를 새로 설정한다. */
 void
 gdt_init (void) {
-	/* Initialize GDT. */
+        /* GDT 초기화 */
 	struct segment_descriptor64 *tss_desc =
 		(struct segment_descriptor64 *) &gdt[SEL_TSS >> 3];
 	struct task_state *tss = tss_get ();
@@ -106,7 +101,7 @@ gdt_init (void) {
 	};
 
 	lgdt (&gdt_ds);
-	/* reload segment registers */
+        /* 세그먼트 레지스터를 다시 로드한다 */
 	asm volatile("movw %%ax, %%gs" :: "a" (SEL_UDSEG));
 	asm volatile("movw %%ax, %%fs" :: "a" (0));
 	asm volatile("movw %%ax, %%es" :: "a" (SEL_KDSEG));
@@ -117,6 +112,6 @@ gdt_init (void) {
 			"pushq %%rax\n"
 			"lretq\n"
 			"1:\n" :: "b" (SEL_KCSEG):"cc","memory");
-	/* Kill the local descriptor table */
+        /* 로컬 디스크립터 테이블을 비운다 */
 	lldt (0);
 }

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -16,14 +16,11 @@
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 
-/* System call.
+/* 시스템 콜 처리.
  *
- * Previously system call services was handled by the interrupt handler
- * (e.g. int 0x80 in linux). However, in x86-64, the manufacturer supplies
- * efficient path for requesting the system call, the `syscall` instruction.
- *
- * The syscall instruction works by reading the values from the the Model
- * Specific Register (MSR). For the details, see the manual. */
+ * 예전에는 인터럽트 핸들러(예: 리눅스의 int 0x80)가 시스템 콜을 담당했지만,
+ * x86-64에서는 `syscall` 명령을 통해 보다 효율적으로 요청할 수 있다.
+ * 이 명령은 모델 특정 레지스터(MSR)의 값을 읽어 동작하니, 자세한 내용은 매뉴얼을 참고. */
 
 #define MSR_STAR 0xc0000081         /* Segment selector msr */
 #define MSR_LSTAR 0xc0000082        /* Long mode SYSCALL target */
@@ -36,9 +33,9 @@ syscall_init (void) {
 			((uint64_t)SEL_KCSEG) << 32);
 	write_msr(MSR_LSTAR, (uint64_t) syscall_entry);	
 
-	/* The interrupt service rountine should not serve any interrupts
-	 * until the syscall_entry swaps the userland stack to the kernel
-	 * mode stack. Therefore, we masked the FLAG_FL. */
+        /* syscall_entry가 사용자 스택을 커널 스택으로 바꿀 때까지는
+         * 인터럽트 핸들러가 다른 인터럽트를 처리하면 안 된다.
+         * 그래서 FLAG_FL 비트를 마스킹해 두었다. */
 	write_msr(MSR_SYSCALL_MASK,
 			FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);	
 

--- a/pintos-kaist/userprog/tss.c
+++ b/pintos-kaist/userprog/tss.c
@@ -7,48 +7,31 @@
 #include "threads/vaddr.h"
 #include "intrinsic.h"
 
-/* The Task-State Segment (TSS).
+/* 태스크 상태 세그먼트(TSS).
  *
- *  Instances of the TSS, an x86-64 specific structure, are used to
- *  define "tasks", a form of support for multitasking built right
- *  into the processor.  However, for various reasons including
- *  portability, speed, and flexibility, most x86-64 OSes almost
- *  completely ignore the TSS.  We are no exception.
+ * x86-64에서 정의된 구조체로, 하드웨어 수준의 멀티태스킹을 위한 "태스크"를
+ * 설명하지만, 이식성이나 성능상의 이유로 대부분의 운영체제는 TSS를 거의
+ * 사용하지 않는다. Pintos 역시 마찬가지다.
  *
- *  Unfortunately, there is one thing that can only be done using
- *  a TSS: stack switching for interrupts that occur in user mode.
- *  When an interrupt occurs in user mode (ring 3), the processor
- *  consults the rsp0 members of the current TSS to determine the
- *  stack to use for handling the interrupt.  Thus, we must create
- *  a TSS and initialize at least these fields, and this is
- *  precisely what this file does.
+ * 다만 사용자 모드에서 발생한 인터럽트의 스택을 전환하는 일만은 TSS 없이는
+ * 불가능하다. 인터럽트가 링3에서 발생하면 프로세서는 현재 TSS의 rsp0 값을
+ * 참고해 사용할 스택을 결정한다. 따라서 최소한 이 필드들을 초기화한 TSS를
+ * 만들어 두어야 하며, 이 파일이 그 역할을 한다.
  *
- *  When an interrupt is handled by an interrupt or trap gate
- *  (which applies to all interrupts we handle), an x86-64 processor
- *  works like this:
- *
- *    - If the code interrupted by the interrupt is in the same
- *      ring as the interrupt handler, then no stack switch takes
- *      place.  This is the case for interrupts that happen when
- *      we're running in the kernel.  The contents of the TSS are
- *      irrelevant for this case.
- *
- *    - If the interrupted code is in a different ring from the
- *      handler, then the processor switches to the stack
- *      specified in the TSS for the new ring.  This is the case
- *      for interrupts that happen when we're in user space.  It's
- *      important that we switch to a stack that's not already in
- *      use, to avoid corruption.  Because we're running in user
- *      space, we know that the current process's kernel stack is
- *      not in use, so we can always use that.  Thus, when the
- *      scheduler switches threads, it also changes the TSS's
- *      stack pointer to point to the new thread's kernel stack.
- *      (The call is in schedule in thread.c.) */
+ * 인터럽트나 트랩 게이트에서 인터럽트를 처리할 때 프로세서는 다음과 같이
+ * 동작한다.
+ *  - 인터럽트가 같은 링에서 발생했다면 스택을 바꾸지 않는다. 즉 커널에서
+ *    발생한 인터럽트라면 TSS 내용은 무시된다.
+ *  - 다른 링에서 발생했다면 TSS에 지정된 스택으로 전환한다. 사용자 공간에서
+ *    인터럽트가 일어날 때가 이에 해당하며, 이미 사용 중이지 않은 스택으로
+ *    바꿔야 한다. 사용자 공간에서는 현재 프로세스의 커널 스택이 비어 있으니
+ *    이를 사용한다. 스케줄러가 스레드를 바꿀 때도 TSS의 스택 포인터를 새
+ *    스레드의 커널 스택으로 바꾼다(schedule 함수 참고). */
 
-/* Kernel TSS. */
+/* 커널용 TSS. */
 struct task_state *tss;
 
-/* Initializes the kernel TSS. */
+/* 커널 TSS를 초기화한다. */
 void
 tss_init (void) {
 	/* Our TSS is never used in a call gate or task gate, so only a
@@ -58,15 +41,14 @@ tss_init (void) {
 	tss_update (thread_current ());
 }
 
-/* Returns the kernel TSS. */
+/* 커널 TSS를 반환한다. */
 struct task_state *
 tss_get (void) {
 	ASSERT (tss != NULL);
 	return tss;
 }
 
-/* Sets the ring 0 stack pointer in the TSS to point to the end
- * of the thread stack. */
+/* TSS의 ring 0 스택 포인터를 해당 스레드 스택 끝으로 설정한다. */
 void
 tss_update (struct thread *next) {
 	ASSERT (tss != NULL);


### PR DESCRIPTION
## Summary
- translate comments in `userprog` source files to Korean
- keep code intact while clarifying explanations

## Testing
- `make -C userprog check` *(fails: devices/kbd.c build error)*