### PR TITLE
Fix device comment translations and build errors

### DIFF
--- a/pintos-kaist/devices/kbd.c
+++ b/pintos-kaist/devices/kbd.c
@@ -10,17 +10,17 @@
 /* 키보드 데이터 레지스터 포트. */
 #define DATA_REG 0x60
 
-/* Shift 키의 현재 상태.
-   눌려 있으면 true, 아니면 false. */
-static bool left_shift, right_shift;    /* 왼쪽/오른쪽 Shift 키. */
-static bool left_alt, right_alt;        /* 왼쪽/오른쪽 Alt 키. */
-static bool left_ctrl, right_ctrl;      /* 왼쪽/오른쪽 Ctrl 키. */
+/* Shift 키들의 현재 상태.
+   눌렸으면 true, 그렇지 않으면 false. */
+static bool left_shift, right_shift;    /* Left and right Shift keys. */
+static bool left_alt, right_alt;        /* Left and right Alt keys. */
+static bool left_ctrl, right_ctrl;      /* Left and right Ctl keys. */
 
 /* Caps Lock 상태.
    켜져 있으면 true, 꺼져 있으면 false. */
 static bool caps_lock;
 
-/* 누른 키의 수. */
+/* 지금까지 눌린 키의 수. */
 static int64_t key_cnt;
 
 static intr_handler_func keyboard_interrupt;
@@ -36,37 +36,40 @@ void
 kbd_print_stats (void) {
 	printf ("Keyboard: %lld keys pressed\n", key_cnt);
 }
-/* 연속된 스캔코드를 문자로 매핑한다. */
-        uint8_t first_scancode;     /* 첫 스캔코드. */
-        const char *chars;          /* chars[0]는 first_scancode에 대응하며
-                                                                   chars[1]은 first_scancode+1에 대응한다. */
-/* Shift 키와 관계없이 항상 같은 문자를 내는 키들.
-   문자 대소문자는 다른 곳에서 처리한다. */
+
+/* 연속된 스캔코드를 문자로 매핑하기 위한 구조체. */
+struct keymap {
+	uint8_t first_scancode;     /* First scancode. */
+	const char *chars;          /* chars[0] has scancode first_scancode,
+								   chars[1] has scancode first_scancode + 1,
+								   and so on to the end of the string. */
 };
 
-/* Shift를 누르지 않았을 때 사용하는 문자들. */
-/* Shift를 누른 상태에서 사용하는 문자들. */
-        /* 키보드 스캔코드. */
-        /* 눌림은 false, 뗌은 true. */
-        /* code에 대응하는 문자. */
-        /* 프리픽스가 있으면 두 번째 바이트까지 읽어 온다. */
-        /* 0x80 비트로 키 눌림/뗌을 구분한다
-           (프리픽스 여부와 무관). */
-                /* Caps Lock 토글. */
-                /* 일반 문자 입력 처리. */
-                        /* Ctrl과 Shift 처리.
-                           Ctrl이 Shift보다 우선한다. */
-                                /* 예: A는 0x41, Ctrl+A는 0x01 등. */
-                        /* Alt는 상위 비트를 세트해 표현한다.
-                           여기서의 0x80은 눌림/뗌 구분과 무관하다. */
-                        /* 키보드 버퍼에 추가한다. */
-                /* 키코드를 시프트 상태 변수로 변환한다. */
-                /* 시프트 키 테이블. */
-                /* 테이블을 순회하여 검색. */
-/* 배열 K에서 SCANCODE를 찾아 해당 문자 값을 *C에 설정하고 true를 반환한다.
-   찾지 못하면 false 를 반환하며 C는 사용하지 않는다. */
-/* Characters for keys pressed with Shift, for those keys where
-   it matters. */
+/* Shift 키와 상관없이 항상 같은 문자를 내는 키들.
+   알파벳 대소문자는 다른 곳에서 처리한다. */
+static const struct keymap invariant_keymap[] = {
+	{0x01, "\033"},
+	{0x0e, "\b"},
+	{0x0f, "\tQWERTYUIOP"},
+	{0x1c, "\r"},
+	{0x1e, "ASDFGHJKL"},
+	{0x2c, "ZXCVBNM"},
+	{0x37, "*"},
+	{0x39, " "},
+	{0, NULL},
+};
+
+/* Shift를 누르지 않았을 때 사용하는 문자. */
+static const struct keymap unshifted_keymap[] = {
+	{0x02, "1234567890-="},
+	{0x1a, "[]"},
+	{0x27, ";'`"},
+	{0x2b, "\\"},
+	{0x33, ",./"},
+	{0, NULL},
+};
+
+/* Shift를 누른 상태에서 사용하는 문자. */
 static const struct keymap shifted_keymap[] = {
 	{0x02, "!@#$%^&*()_+"},
 	{0x1a, "{}"},
@@ -80,68 +83,67 @@ static bool map_key (const struct keymap[], unsigned scancode, uint8_t *);
 
 static void
 keyboard_interrupt (struct intr_frame *args UNUSED) {
-	/* Status of shift keys. */
+        /* Shift 키 상태. */
 	bool shift = left_shift || right_shift;
 	bool alt = left_alt || right_alt;
 	bool ctrl = left_ctrl || right_ctrl;
 
-	/* Keyboard scancode. */
+        /* 키보드 스캔코드. */
 	unsigned code;
 
-	/* False if key pressed, true if key released. */
+        /* 키가 눌렸다면 false, 떼면 true. */
 	bool release;
 
-	/* Character that corresponds to `code'. */
+        /* `code`에 해당하는 문자. */
 	uint8_t c;
 
-	/* Read scancode, including second byte if prefix code. */
+        /* 프리픽스 코드면 두 번째 바이트까지 읽어 스캔코드를 구한다. */
 	code = inb (DATA_REG);
 	if (code == 0xe0)
 		code = (code << 8) | inb (DATA_REG);
 
-	/* Bit 0x80 distinguishes key press from key release
-	   (even if there's a prefix). */
+        /* 0x80 비트는 키의 눌림과 뗌을 구분한다
+           (프리픽스 여부와 무관). */
 	release = (code & 0x80) != 0;
 	code &= ~0x80u;
 
-	/* Interpret key. */
+        /* 스캔코드를 해석한다. */
 	if (code == 0x3a) {
-		/* Caps Lock. */
+                /* Caps Lock 키. */
 		if (!release)
 			caps_lock = !caps_lock;
 	} else if (map_key (invariant_keymap, code, &c)
 			|| (!shift && map_key (unshifted_keymap, code, &c))
 			|| (shift && map_key (shifted_keymap, code, &c))) {
-		/* Ordinary character. */
+                /* 일반 문자 입력. */
 		if (!release) {
-			/* Handle Ctrl, Shift.
-			   Note that Ctrl overrides Shift. */
+                        /* Ctrl과 Shift 처리.
+                           Ctrl이 Shift보다 우선한다. */
 			if (ctrl && c >= 0x40 && c < 0x60) {
-				/* A is 0x41, Ctrl+A is 0x01, etc. */
+                                /* 예: A는 0x41, Ctrl+A는 0x01 등. */
 				c -= 0x40;
 			} else if (shift == caps_lock)
 				c = tolower (c);
 
-			/* Handle Alt by setting the high bit.
-			   This 0x80 is unrelated to the one used to
-			   distinguish key press from key release. */
+                        /* Alt는 상위 비트를 세트한다.
+                           여기서의 0x80은 눌림/뗌 판별용과 무관하다. */
 			if (alt)
 				c += 0x80;
 
-			/* Append to keyboard buffer. */
+                        /* 키보드 버퍼에 추가한다. */
 			if (!input_full ()) {
 				key_cnt++;
 				input_putc (c);
 			}
 		}
 	} else {
-		/* Maps a keycode into a shift state variable. */
+                /* 키코드를 시프트 상태 변수에 매핑한다. */
 		struct shift_key {
 			unsigned scancode;
 			bool *state_var;
 		};
 
-		/* Table of shift keys. */
+                /* 시프트 키 테이블. */
 		static const struct shift_key shift_keys[] = {
 			{  0x2a, &left_shift},
 			{  0x36, &right_shift},
@@ -154,7 +156,7 @@ keyboard_interrupt (struct intr_frame *args UNUSED) {
 
 		const struct shift_key *key;
 
-		/* Scan the table. */
+                /* 테이블을 순회하며 검색한다. */
 		for (key = shift_keys; key->scancode != 0; key++)
 			if (key->scancode == code) {
 				*key->state_var = !release;
@@ -163,10 +165,9 @@ keyboard_interrupt (struct intr_frame *args UNUSED) {
 	}
 }
 
-/* Scans the array of keymaps K for SCANCODE.
-   If found, sets *C to the corresponding character and returns
-   true.
-   If not found, returns false and C is ignored. */
+/* 배열 K에서 SCANCODE에 해당하는 문자를 찾는다.
+   찾으면 *C에 저장하고 true를 반환한다.
+   없으면 false를 반환하며 C는 사용하지 않는다. */
 static bool
 map_key (const struct keymap k[], unsigned scancode, uint8_t *c) {
 	for (; k->first_scancode != 0; k++)

--- a/pintos-kaist/include/userprog/syscall.h
+++ b/pintos-kaist/include/userprog/syscall.h
@@ -4,7 +4,7 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
 
-struct lock filesys_lock;	
+extern struct lock filesys_lock;
 
 void syscall_init (void);
 void validate_addr(const void *addr);

--- a/pintos-kaist/threads/init.c
+++ b/pintos-kaist/threads/init.c
@@ -167,8 +167,7 @@ paging_init (uint64_t mem_end) {
 	pml4_activate(0);
 }
 
-/* Breaks the kernel command line into words and returns them as
-   an argv-like array. */
+/* 커널 명령줄을 공백 기준으로 나누어 argv 형태의 배열로 반환한다. */
 static char **
 read_command_line (void) {
 	static char *argv[LOADER_ARGS_LEN / 2 + 1];
@@ -200,8 +199,8 @@ read_command_line (void) {
 	return argv;
 }
 
-/* Parses options in ARGV[]
-   and returns the first non-option argument. */
+/* ARGV[]에 있는 옵션을 해석하고
+   옵션이 아닌 첫 번째 인자를 반환한다. */
 static char **
 parse_options (char **argv) {
 	for (; *argv != NULL && **argv == '-'; argv++) {
@@ -234,7 +233,7 @@ parse_options (char **argv) {
 	return argv;
 }
 
-/* Runs the task specified in ARGV[1]. */
+/* ARGV[1]에 지정된 작업을 실행한다. */
 static void
 run_task (char **argv) {
 	const char *task = argv[1];
@@ -252,18 +251,18 @@ run_task (char **argv) {
 	printf ("Execution of '%s' complete.\n", task);
 }
 
-/* Executes all of the actions specified in ARGV[]
-   up to the null pointer sentinel. */
+/* ARGV[]에 지정된 모든 동작을
+   NULL 포인터가 나올 때까지 실행한다. */
 static void
 run_actions (char **argv) {
-	/* An action. */
+        /* 개별 동작을 나타내는 구조체. */
 	struct action {
-		char *name;                       /* Action name. */
-		int argc;                         /* # of args, including action name. */
-		void (*function) (char **argv);   /* Function to execute action. */
+                char *name;                       /* 동작 이름. */
+                int argc;                         /* 동작 이름을 포함한 인자 수. */
+                void (*function) (char **argv);   /* 동작을 수행할 함수. */
 	};
 
-	/* Table of supported actions. */
+        /* 지원하는 동작 목록. */
 	static const struct action actions[] = {
 		{"run", 2, run_task},
 #ifdef FILESYS
@@ -280,27 +279,26 @@ run_actions (char **argv) {
 		const struct action *a;
 		int i;
 
-		/* Find action name. */
+                /* 실행할 동작을 찾는다. */
 		for (a = actions; ; a++)
 			if (a->name == NULL)
 				PANIC ("unknown action `%s' (use -h for help)", *argv);
 			else if (!strcmp (*argv, a->name))
 				break;
 
-		/* Check for required arguments. */
+                /* 필요한 인자가 있는지 확인한다. */
 		for (i = 1; i < a->argc; i++)
 			if (argv[i] == NULL)
 				PANIC ("action `%s' requires %d argument(s)", *argv, a->argc - 1);
 
-		/* Invoke action and advance. */
+                /* 동작을 실행한 뒤 다음으로 이동한다. */
 		a->function (argv);
 		argv += a->argc;
 	}
 
 }
 
-/* Prints a kernel command line help message and powers off the
-   machine. */
+/* 커널 명령줄 사용법을 출력하고 시스템을 종료한다. */
 static void
 usage (void) {
 	printf ("\nCommand line syntax: [OPTION...] [ACTION...]\n"
@@ -334,8 +332,7 @@ usage (void) {
 }
 
 
-/* Powers down the machine we're running on,
-   as long as we're running on Bochs or QEMU. */
+/* Bochs나 QEMU에서 실행 중이라면 전원을 끈다. */
 void
 power_off (void) {
 #ifdef FILESYS
@@ -349,7 +346,7 @@ power_off (void) {
 	for (;;);
 }
 
-/* Print statistics about Pintos execution. */
+/* Pintos 실행 통계를 출력한다. */
 static void
 print_stats (void) {
 	timer_print_stats ();

--- a/pintos-kaist/threads/mmu.c
+++ b/pintos-kaist/threads/mmu.c
@@ -139,7 +139,7 @@ pdp_for_each (uint64_t *pdp,
 	return true;
 }
 
-/* Apply FUNC to each available pte entries including kernel's. */
+/* 커널 영역을 포함한 모든 PTE 엔트리에 FUNC를 적용한다. */
 bool
 pml4_for_each (uint64_t *pml4, pte_for_each_func *func, void *aux) {
 	for (unsigned i = 0; i < PGSIZE / sizeof(uint64_t *); i++) // 왜 PGSIZE / sizeof(uint64_t *)만큼 반복할까?

--- a/pintos-kaist/threads/palloc.c
+++ b/pintos-kaist/threads/palloc.c
@@ -112,10 +112,10 @@ resolve_area_info (struct area *base_mem, struct area *ext_mem) {
 }
 
 /*
- * Populate the pool.
- * All the pages are manged by this allocator, even include code page.
- * Basically, give half of memory to kernel, half to user.
- * We push base_mem portion to the kernel as much as possible.
+ * 풀을 초기화한다.
+ * 코드 페이지까지 모든 메모리를 이 할당자가 관리하며,
+ * 기본적으로 메모리를 절반씩 커널과 사용자에게 나눈다.
+ * 가능한 한 base_mem 영역을 커널에 우선 배정한다.
  */
 static void
 populate_pools (struct area *base_mem, struct area *ext_mem) {
@@ -251,12 +251,10 @@ palloc_init (void) {
 	return ext_mem.end;
 }
 
-/* Obtains and returns a group of PAGE_CNT contiguous free pages.
-   If PAL_USER is set, the pages are obtained from the user pool,
-   otherwise from the kernel pool.  If PAL_ZERO is set in FLAGS,
-   then the pages are filled with zeros.  If too few pages are
-   available, returns a null pointer, unless PAL_ASSERT is set in
-   FLAGS, in which case the kernel panics. */
+/* PAGE_CNT개의 연속된 빈 페이지를 할당해 반환한다.
+   PAL_USER가 지정되면 사용자 풀에서, 아니면 커널 풀에서 얻는다.
+   PAL_ZERO가 설정되면 페이지를 0으로 채운다.
+   남은 페이지가 부족하면 NULL을 반환하지만 PAL_ASSERT가 설정되어 있으면 패닉을 일으킨다. */
 void *
 palloc_get_multiple (enum palloc_flags flags, size_t page_cnt) {
 	struct pool *pool = flags & PAL_USER ? &user_pool : &kernel_pool;
@@ -282,13 +280,10 @@ palloc_get_multiple (enum palloc_flags flags, size_t page_cnt) {
 	return pages;
 }
 
-/* Obtains a single free page and returns its kernel virtual
-   address.
-   If PAL_USER is set, the page is obtained from the user pool,
-   otherwise from the kernel pool.  If PAL_ZERO is set in FLAGS,
-   then the page is filled with zeros.  If no pages are
-   available, returns a null pointer, unless PAL_ASSERT is set in
-   FLAGS, in which case the kernel panics. */
+/* 빈 페이지 한 장을 얻어 커널 가상 주소를 반환한다.
+   PAL_USER가 있으면 사용자 풀에서, 아니면 커널 풀에서 가져온다.
+   PAL_ZERO가 지정되면 페이지를 0으로 채운다.
+   할당할 페이지가 없으면 NULL을 반환하지만 PAL_ASSERT가 설정되어 있으면 패닉을 일으킨다. */
 void *
 palloc_get_page (enum palloc_flags flags) {
 	return palloc_get_multiple (flags, 1);

--- a/pintos-kaist/threads/synch.c
+++ b/pintos-kaist/threads/synch.c
@@ -142,7 +142,7 @@
 	   printf ("done.\n");
    }
    
-   /* Thread function used by sema_self_test(). */
+   /* sema_self_test()에서 사용하는 스레드 함수. */
    static void
    sema_test_helper (void *sema_) {
 	   struct semaphore *sema = sema_;

--- a/pintos-kaist/threads/thread.c
+++ b/pintos-kaist/threads/thread.c
@@ -730,16 +730,14 @@ do_iret (struct intr_frame *tf) {
 			: : "g" ((uint64_t) tf) : "memory");
 }
 
-/* Switching the thread by activating the new thread's page
-   tables, and, if the previous thread is dying, destroying it.
+/* 새 스레드의 페이지 테이블을 활성화하여 스레드를 전환한다.
+   이전 스레드가 종료 상태이면 이곳에서 파괴한다.
 
-   At this function's invocation, we just switched from thread
-   PREV, the new thread is already running, and interrupts are
-   still disabled.
+   이 함수가 호출될 때는 이미 PREV 스레드에서 전환된 뒤이며
+   새 스레드가 실행 중이고 인터럽트는 아직 꺼져 있다.
 
-   It's not safe to call printf() until the thread switch is
-   complete.  In practice that means that printf()s should be
-   added at the end of the function. */
+   스레드 전환이 끝나기 전에는 printf() 사용이 안전하지 않다.
+   실제로는 함수 끝부분에서만 printf()를 호출해야 한다. */
 static void
 thread_launch (struct thread *th) {
 	uint64_t tf_cur = (uint64_t) &running_thread ()->tf;

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -16,6 +16,9 @@
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 
+/* 파일 시스템 동기화를 위한 전역 락. */
+struct lock filesys_lock;
+
 /* System call.
  *
  * Previously system call services was handled by the interrupt handler


### PR DESCRIPTION
## Summary
- restore missing code in device modules and translate comments
- expose filesys_lock as extern in header and define in syscall.c

## Testing
- `make` (fails with multiple definition of test_name)
